### PR TITLE
Add a custom HTTP header with Puppet

### DIFF
--- a/0x0F-load_balancer/2-puppet_custom_http_response_header.pp
+++ b/0x0F-load_balancer/2-puppet_custom_http_response_header.pp
@@ -1,0 +1,25 @@
+# creating a custome header with puppet
+
+exec { 'update':
+        provider => shell,
+        command => 'sudo apt-get -y update',
+        before => Exec['install Nginx']
+}
+
+exec {'install Nginx':
+        provider => shell,
+        command => 'sudo apt-get -y install nginx',
+        before => Exec['install nginx'],
+}
+
+exec { 'add_header':
+        provider => shell,
+        environment => ["HOST=${hostname}"],
+        command => 'sudo sed -i "s/include \/etc\/nginx\/sites-enabled\/*;/include \/etc\/nginx\/sites-enabled\/\*;\n\tadd_header X-Served-By \"$HOST\";/" /etc/nginx/nginx.conf',
+        before => Exec['restart Nginx'],
+}
+
+exec { 'restart Nginx':
+        provider => shell,
+        command => 'sudo service nginx restart',
+}


### PR DESCRIPTION
Just as in task #0, this is an automation of the task on creating a custom HTTP header response, but with Puppet.